### PR TITLE
Add my-meetings rel

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const D2LHypermediaRels = {
 	firstName: 'https://api.brightspace.com/rels/first-name',
 	lastName: 'https://api.brightspace.com/rels/last-name',
 	myEnrollments: 'https://api.brightspace.com/rels/my-enrollments',
+	myMeetings: 'https://meetings.api.brightspace.com/rels/my-meetings',
 	myNotifications: 'https://notifications.api.brightspace.com/rels/my-notifications',
 	myOrganizationGrades: 'https://api.brightspace.com/rels/my-organization-grades',
 	myOrganizationAwards: 'https://api.brightspace.com/rels/my-organization-awards',


### PR DESCRIPTION
This should probably be in a `Meetings` sub-domain but all of the other `my*` rels are in the main area, including `myNotifications` which matches this pattern. So for 'consistency', and for now, placing it here.

Used here: https://github.com/Brightspace/parent-portal-ui/pull/696/files#diff-c65a063fbab6389c0d0aea3530319547R123