### PR TITLE
Match package to current release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "d2l-hypermedia-constants",
   "description": "Library of constants for communicating with D2L's Hypermedia APIs",
-  "version": "5.23.0",
+  "version": "5.27.0",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
I guess we've been doing manual releases rather than using the version/tag thing document in the README, because this value does not match the release version. Bumping this up to bring it in line.