### PR TITLE
add ./ to index.js import and annotate behaviour

### DIFF
--- a/d2l-hypermedia-constants.js
+++ b/d2l-hypermedia-constants.js
@@ -1,4 +1,4 @@
-import {Actions, Classes, Rels} from 'index.js';
+import {Actions, Classes, Rels} from './index.js';
 
 window.D2L = window.D2L || {};
 window.D2L.Hypermedia = window.D2L.Hypermedia || {};
@@ -7,6 +7,7 @@ window.D2L.Hypermedia.Constants = {
 	Classes: Classes,
 	Rels: Rels
 };
+
 // for backwards-compatibility
 window.D2L.Hypermedia.HMConstantsBehavior = {
 	HypermediaActions: Actions,


### PR DESCRIPTION
In d2l-rubric p3 conversion, I have been seeing "Could not resolve module specifier "index.js" in file "C:\source\d2l-rubric\node_modules\d2l-hypermedia-constants\d2l-hypermedia-constants.js"."

This PR is to correct the issue. 