### PR TITLE
US103199 - Add sorts rel

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ export const Rels = {
 	rubric: 'https://api.brightspace.com/rels/rubric',
 	semesters: 'https://api.brightspace.com/rels/semesters',
 	sequence: 'https://api.brightspace.com/rels/sequence',
+	sorts: 'https://api.brightspace.com/rels/sorts',
 	thumbnailRegular: 'https://api.brightspace.com/rels/thumbnail#regular',
 	thumbnailSmall: 'https://api.brightspace.com/rels/thumbnail#small',
 	userProfile: 'https://api.brightspace.com/rels/user-profile',


### PR DESCRIPTION
This rel identifies that the current entity represents sorts that could be applied to your collections route (the exact same as the `filters` rel, except for sorting)