### PR TITLE
Add canonical-user rel

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,9 @@ export const Rels = {
 	},
 	Meetings: {
 		meetingManagementTool: 'https://meetings.api.brightspace.com/rels/meeting-management-tool'
+	},
+	Users: {
+		canonicalUser: 'https://users.api.brightspace.com/rels/canonical-user'
 	}
 };
 


### PR DESCRIPTION
This link is added by the `CanonicalUserEnrolledUserLinkProvider` - been around for a while, just never made it into here.