### PR TITLE
Add `annotated` and `assignment-submission` classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,9 @@ export const Classes = {
 		userSurveyActivity: 'user-survey-activity'
 	},
 	assignments: {
+		annotated: 'annotated',
 		assignment: 'assignment',
+		assignmentSubmission: 'assignment-submission',
 		attachment: 'attachment',
 		attachmentList: 'attachment-list',
 		instructions: 'instructions',


### PR DESCRIPTION
Adding 2 missing classes for assignments:
- `annotated` for annotated pdf download links
- `assignment-submission` for assignment submission entities, which was previously missing