### PR TITLE
Add consortium things

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,6 +223,10 @@ export const Classes = {
 	conditions: {
 		section: 'section'
 	},
+	consortium: {
+		token: 'token',
+		tokens: 'tokens'
+	},
 	content: {
 		content: 'content',
 		sequencedActivity: 'sequenced-activity',


### PR DESCRIPTION
[This](https://github.com/BrightspaceHypermediaComponents/siren-sdk/blob/master/src/hypermedia-constants.js) probably shouldn't be a thing. It seems to only be a thing because of these two unique items. I'm proposing we add them here so we can remove that thing. Or, I'd be fine with moving them into their own thing, but either way deleting that other thing and just referencing this thing. While I understand long term there appears to be a push to remove this thing, I think having both things in the interim is a bad idea.

If nothing else I hope this PR begins some discussion about the present and future of these things, in a way that results in the betterment of all the things down the road.