### PR TITLE
US130301 - adding constant for quiz rel under quizzes API subdomain

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,8 @@ export const Rels = {
 	},
 	// Quizzes API sub-domain rels
 	Quizzes: {
-		description: 'https://quizzes.api.brightspace.com/rels/description'
+		description: 'https://quizzes.api.brightspace.com/rels/description',
+		quiz: 'https://quizzes.api.brightspace.com/rels/quiz'
 	},
 	// Themes API sub-domain rels
 	Themes: {


### PR DESCRIPTION
[US130301 ](https://rally1.rallydev.com/#/42960320374d/dashboard?detail=%2Fuserstory%2F605256500003) on Rally.

Needed for https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/pull/660