### PR TITLE
Add search-course-collection action

### DIFF
--- a/index.js
+++ b/index.js
@@ -480,6 +480,7 @@ export const Actions = {
 	},
 	organizations: {
 		removeHomepageBanner: 'remove-homepage-banner',
+		searchCourseCollection: 'search-course-collection',
 		setCatalogImage: 'set-catalog-image'
 	},
 	activities: {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "homepage": "https://github.com/Brightspace/d2l-hm-constants-behavior#readme",
   "name": "d2l-hypermedia-constants",
-  "version": "6.66.0",
+  "version": "6.67.0",
   "main": "dist/index.js",
   "module": "index.js",
   "scripts": {


### PR DESCRIPTION
Adding `search-course-collection` constant from `Organization` entity to be used to get the course list in Course Publisher.