### PR TITLE
Publish with incremental-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,5 @@ jobs:
         with:
           DEFAULT_INCREMENT: minor
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
-      - name: Publish to NPM
-        if: steps.incremental-release.outputs.VERSION != ''
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Hi 👋 , I'm from team Gaudi. This PR is to fix an issue we identified with `incremental-release` where changes on maintenance branches (e.g. hotfixes on `release/2022.9.x`) are being published as "latest" and being used by the current BSI, instead of it using only the main branch.

This change moves publishing into `incremental-release`, which will tag maintenance branch releases appropriately so that they're not treated as `latest`. We recently made similar changes with `match-lms-release`, e.g. here:
https://github.com/Brightspace/consistent-evaluation/pull/1084

Note that we will also need to make these changes on any active maintenance branches, so that they use the proper pipeline.

If this repo supports squash merging, then this PR won't trigger a release - I will include `[skip ci][skip version]` in the merge commit.

## Required action

Please let me know if there are any maintenance branches on this repo that may receive hotfixes in the future, so that we can also backport these changes there. This includes any maintenance branch that may be made in the future for `20.22.10`.

Thanks!

## More info

Rally: https://rally1.rallydev.com/#/?detail=/userstory/646357845471&fdp=true