### PR TITLE
Add advanced-assessment class

### DIFF
--- a/index.js
+++ b/index.js
@@ -381,6 +381,7 @@ export const Classes = {
 		unpinned: 'unpinned'
 	},
 	explicitEvaluations: {
+		advancedAssessment: 'advanced-assessment',
 		aggregatedEvaluation: 'aggregated-evaluation',
 		explicitEvaluationCompleted: 'completed',
 		explicitEvaluationEntity: 'explicit-evaluation-entity',


### PR DESCRIPTION
- [US151818](https://rally1.rallydev.com/#/?detail=/userstory/698745477223&fdp=true): [FACE] Add activity details to the rubrics popout for non-ME evaluations
- [US152087](https://rally1.rallydev.com/#/?detail=/userstory/699342559785&fdp=true): [AA][ME][FACE] Adding activity details to the rubrics popout—Aggregate 
- Brightspace/lms#35784
- Brightspace/consistent-evaluation#1567

Helps determine whether or not to display the new activity details component in popout rubrics
`explicitEvaluations` may not be the ideal location for this class