### PR TITLE
Fix spelling mistake

### DIFF
--- a/index.js
+++ b/index.js
@@ -513,7 +513,7 @@ export const Classes = {
 		intent: 'intent',
 		intents: 'intents',
 		intentList: 'intent-list',
-		levelOfAchievement: 'level-of-achievment',
+		levelOfAchievement: 'level-of-achievement',
 		organizationIntentList: 'organization-intent-list',
 		outcome: 'outcome',
 		outcomes: 'outcomes',


### PR DESCRIPTION
This fixes all instances of `level-of-achievment`. The [backend](https://github.com/Brightspace/lms/blob/master/le/lo/D2L.LE.LO/Extensibility/Hypermedia/Demonstrations/Entities/LoaLevel/Serializers/LoaLevelSerializer.cs#L99-L100) sends both `level-of-achievment` and `level-of-achievement` so this is fine. Will remove workaround in backend once all other instances of the spelling error are gone.

Outcomes change: https://github.com/Brightspace/d2l-outcomes/pull/697
LMS change: https://github.com/Brightspace/lms/pull/39097