### PR TITLE
[US156910] Add in hypermedia constants to be used in outcome scale cr…

### DIFF
--- a/index.js
+++ b/index.js
@@ -516,7 +516,6 @@ export const Classes = {
 	outcomes: {
 		availableAchievementScale: 'available-achievement-scale',
 		assessed: 'assessed',
-		clearAchievementThreshold: 'clear-achievement-threshold',
 		demonstration: 'demonstration',
 		demonstratableLevel: 'demonstratable-level',
 		intent: 'intent',
@@ -527,7 +526,6 @@ export const Classes = {
 		outcome: 'outcome',
 		outcomes: 'outcomes',
 		selected: 'selected',
-		setAchievementThreshold: 'set-achievement-threshold',
 		suggested: 'suggested'
 	},
 	meetings: {
@@ -663,9 +661,11 @@ export const Actions = {
 		setCatalogImage: 'set-catalog-image'
 	},
 	outcomes: {
+		clearAchievementThreshold: 'clear-achievement-threshold',
 		commitChanges: 'commit-changes',
 		discardChanges: 'discard-changes',
-		select: 'select'
+		select: 'select',
+		setAchievementThreshold: 'set-achievement-threshold'
 	},
 	quizzes: {
 		autoGrade: 'auto-grade'

--- a/index.js
+++ b/index.js
@@ -516,6 +516,7 @@ export const Classes = {
 	outcomes: {
 		availableAchievementScale: 'available-achievement-scale',
 		assessed: 'assessed',
+		clearAchievementThreshold: 'clear-achievement-threshold',
 		demonstration: 'demonstration',
 		demonstratableLevel: 'demonstratable-level',
 		intent: 'intent',

--- a/index.js
+++ b/index.js
@@ -254,6 +254,7 @@ export const Rels = {
 		level: 'https://achievements.api.brightspace.com/rels/level'
 	},
 	Outcomes: {
+		availableAchievementScale: 'https://outcomes.api.brightspace.com/rels/loa',
 		intents: 'https://outcomes.api.brightspace.com/rels/intents',
 		intent: 'https://outcomes.api.brightspace.com/rels/intent',
 		outcome: 'https://outcomes.api.brightspace.com/rels/outcome'
@@ -513,6 +514,7 @@ export const Classes = {
 		selected: 'selected'
 	},
 	outcomes: {
+		availableAchievementScale: 'available-achievement-scale',
 		assessed: 'assessed',
 		demonstration: 'demonstration',
 		demonstratableLevel: 'demonstratable-level',
@@ -524,6 +526,7 @@ export const Classes = {
 		outcome: 'outcome',
 		outcomes: 'outcomes',
 		selected: 'selected',
+		setAchievementThreshold: 'set-achievement-threshold',
 		suggested: 'suggested'
 	},
 	meetings: {


### PR DESCRIPTION
…eation for test bench.

Rally ticket: [US156910](https://rally1.rallydev.com/#/57732444928d/dashboard?detail=%2Fuserstory%2F720462780607)

Adding in a `Rel` link and keyword  in `Classes` for `available-achievement-scale`
Adding in keyword in `Actions` for `set-achievement-threshold` and `clear-achievement-threshold`

I believe I did this correctly from the current patterns. Let me know if this needs to be modified. I will use these constants in my test-bench PR.

![available-achievement-scale](https://github.com/Brightspace/d2l-hypermedia-constants/assets/57574063/7a9f17b9-a6e4-427d-892c-d2b0af2b7b4a)

![set-achievement-threshold](https://github.com/Brightspace/d2l-hypermedia-constants/assets/57574063/b7759f11-5341-4ed4-a642-e99b7d12c380)
