### PR TITLE
PHNX-2108: Get data for row-content for quizzes

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,8 @@ export const Rels = {
 		quiz: 'https://quizzes.api.brightspace.com/rels/quiz',
 		section: 'https://quizzes.api.brightspace.com/rels/quiz-section',
 		studyRecommendations: 'https://quizzes.api.brightspace.com/rels/studyRecommendations',
-		timing: 'https://quizzes.api.brightspace.com/rels/timing'
+		timing: 'https://quizzes.api.brightspace.com/rels/timing',
+		viewSubmissionResults: 'https://quizzes.api.brightspace.com/rels/view-quiz-submission-results'
 	},
 	// Themes API sub-domain rels
 	Themes: {

--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ export const Rels = {
 		section: 'https://quizzes.api.brightspace.com/rels/quiz-section',
 		studyRecommendations: 'https://quizzes.api.brightspace.com/rels/studyRecommendations',
 		timing: 'https://quizzes.api.brightspace.com/rels/timing',
-		viewSubmissionResults: 'https://quizzes.api.brightspace.com/rels/view-quiz-submission-results'
+		viewQuizSubmissionResults: 'https://quizzes.api.brightspace.com/rels/view-quiz-submission-results'
 	},
 	// Themes API sub-domain rels
 	Themes: {


### PR DESCRIPTION
JIRA Link: [PHNX-2108](https://desire2learn.atlassian.net/browse/PHNX-2108)

This PR adds a Quizzes.viewSubmissionResults Rel (`https://quizzes.api.brightspace.com/rels/view-quiz-submission-results`). This is added for explicitly differentiating the `submissionLink` in the `actor-quiz-attempt-activity-provider` (vs. just looking for the `relative-uri` sub-entity), see related PRs below.

# Related PRs
- UCE: https://github.com/Brightspace/unified-content-experience/pull/1561
- LMS: https://github.com/Brightspace/lms/pull/58192

[PHNX-2108]: https://desire2learn.atlassian.net/browse/PHNX-2108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ