### PR TITLE
EP-1344: Add Description Const to Content

### DIFF
--- a/index.js
+++ b/index.js
@@ -374,6 +374,7 @@ export const Classes = {
 	},
 	content: {
 		content: 'content',
+		description: 'description',
 		sequence: 'sequence',
 		sequencedActivity: 'sequenced-activity',
 		sequenceDescription: 'sequence-description',


### PR DESCRIPTION
## JIRA Link
[EP-1344: Activity Display > 20.25.1 > description section is displaying at the top of the page for lti 1.1](https://desire2learn.atlassian.net/browse/EP-1344)

## Description
- This PR adds a description const the Content to enable LTI descriptions.

## Related PRS
1.  https://github.com/Brightspace/smart-curriculum/pull/2229 *Remove old description view when AD
2. https://github.com/Brightspace/unified-content-experience/pull/1749 *Add new description

![image](https://github.com/user-attachments/assets/2c447e43-caa6-4a8e-93dd-70595ba2c22c)
_screenshot of old_

![image](https://github.com/user-attachments/assets/067ab491-d547-42d8-8a84-4563247245e5)
_screenshot of new_