### PR TITLE
fix: VOY-3448: Add user-course-grades Rel in Grades

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ export const Rels = {
 		grade: 'https://grades.api.brightspace.com/rels/grade',
 		userGrade: 'https://grades.api.brightspace.com/rels/user-grade',
 		weight: 'https://grades.api.brightspace.com/rels/weight',
-		userEnrollmentGrades: 'https://grades.api.brightspace.com/rels/user-enrollment-grades'
+		userCourseGrades: 'https://grades.api.brightspace.com/rels/user-course-grades'
 	},
 	// Questions API sub-domain rels
 	Questions: {


### PR DESCRIPTION
Related PRs:
https://github.com/Brightspace/lms/pull/68800
https://github.com/Brightspace/parent-portal-ui/pull/1808

https://desire2learn.atlassian.net/browse/VOY-3448