### PR TITLE
remove registry-url from Brightspace/setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
         uses: Brightspace/setup-node@main
         with:
           node-version-file: .nvmrc
-          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm install
       - name: Build

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "d2l-hypermedia-constants.js",
     "index.js"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "scripts": {
     "build": "babel index.js --out-dir ./dist"
   },


### PR DESCRIPTION
The `registry-url` input will soon be managed by Brightspace/setup-node itself.
The registry to publish packages to is now defined in `publishConfig` in `package.json`.

[HOD-4561 - Proxy Registry > Update Brightspace/setup-node](https://desire2learn.atlassian.net/browse/HOD-4561)